### PR TITLE
fix #59 camera.projectionMatrix.elements.set is not a function

### DIFF
--- a/js/artoolkit.three.js
+++ b/js/artoolkit.three.js
@@ -114,8 +114,11 @@
 			var scene = new THREE.Scene();
 			var camera = new THREE.Camera();
 			camera.matrixAutoUpdate = false;
-			camera.projectionMatrix.elements.set(this.getCameraMatrix());
-
+			if (typeof camera.projectionMatrix.elements.set === "function") {
+				camera.projectionMatrix.elements.set(this.getCameraMatrix());
+			} else {
+				camera.projectionMatrix.elements=[].slice.call(this.getCameraMatrix());
+			}
 			scene.add(camera);
 
 
@@ -257,7 +260,11 @@
 
 				}
 				if (obj) {
-					obj.matrix.elements.set(ev.data.matrix);
+					if (typeof obj.matrix.elements.set === "function") {
+						obj.matrix.elements.set(ev.data.matrix);
+					} else {
+						obj.matrix.elements=[].slice.call(ev.data.matrix);
+					}
 					obj.visible = true;
 				}
 			});
@@ -268,7 +275,11 @@
 			this.addEventListener('getMultiMarker', function(ev) {
 				var obj = this.threeMultiMarkers[ev.data.multiMarkerId];
 				if (obj) {
-					obj.matrix.elements.set(ev.data.matrix);
+					if (typeof obj.matrix.elements.set === "function") {
+						obj.matrix.elements.set(ev.data.matrix);
+					} else {
+						obj.matrix.elements=[].slice.call(ev.data.matrix);
+					}
 					obj.visible = true;
 				}
 			});
@@ -283,7 +294,11 @@
 				var obj = this.threeMultiMarkers[marker];
 				if (obj && obj.markers && obj.markers[subMarkerID]) {
 					var sub = obj.markers[subMarkerID];
-					sub.matrix.elements.set(ev.data.matrix);
+					if (typeof sub.matrix.elements.set === "function") {
+						sub.matrix.elements.set(ev.data.matrix);
+					} else {
+						sub.matrix.elements=[].slice.call(ev.data.matrix);
+					}
 					sub.visible = (subMarker.visible >= 0);
 				}
 			});


### PR DESCRIPTION
For Three.js r85 and upper, users will have  camera.projectionMatrix.elements.set is not a function error due to the change of Matrix4 elements data structure. This is to workaround that.