### PR TITLE
update threejs based examples to reflect modern threejs API

### DIFF
--- a/doc/introduction.html
+++ b/doc/introduction.html
@@ -250,7 +250,7 @@ arController.addEventListener('getMarker', function(ev) {
 		markerRoot.visible = true;
 
 		// Copy the marker transformation matrix to the markerRoot matrix.
-		markerRoot.matrix.elements.set(ev.matrix);
+		markerRoot.matrix.set(ev.matrix);
 
 	}
 });
@@ -278,7 +278,7 @@ camera.matrixAutoUpdate = false;
 
 // Set the camera matrix to the AR camera matrix.
 //
-camera.matrix.elements.set(arController.getCameraMatrix());
+camera.matrix.set(arController.getCameraMatrix());
 
 // On each frame, detect markers, update their positions and
 // render the frame on the renderer.
@@ -302,7 +302,7 @@ tick();
 <p>Don't let the above scare you, it's just got a lot of comments for a few lines of code. That takes care of rendering the AR scene on renderer and tracking a barcode marker. You probably also want to overlay the AR scene on top of the video feed. Let's add that. Nothing too complicated, just drawing a plane with the video on it before anything else.
 
 <pre class="prettyprint"><code>// To display the video, first create a texture from it.
-var videoTex = new THREE.Texture(video);
+var videoTex = new THREE.VideoTexture(video);
 
 // Use linear downscaling for videoTex
 // (otherwise it needs to be power-of-two sized and you


### PR DESCRIPTION
eg. `new THREE.Texture(video);` would not work anyore in the latest threejs v86 that is also used in the examples. Same goes for setting the matrix, instead of `matrix.elements.set` it has to be `matrix.set`.