### PR TITLE
Fixes "TypeError: Type error" on Safari

### DIFF
--- a/js/artoolkit.api.js
+++ b/js/artoolkit.api.js
@@ -1155,7 +1155,7 @@
 
 		var success = function(stream) {
 			video.addEventListener('loadedmetadata', initProgress, false);
-			video.src = window.URL.createObjectURL(stream);
+			video.srcObject = stream;
 			readyToPlay = true;
 			play(); // Try playing without user input, should work on non-Android Chrome
 		};


### PR DESCRIPTION
Fixes "TypeError: Type error" on Safari (Mac/iOS) 
fixes #74 #40 